### PR TITLE
classpath: replaced specific version numbers of jar files with wildcards

### DIFF
--- a/oxygen-tei/frameworks/tei/teip5jtei.framework
+++ b/oxygen-tei/frameworks/tei/teip5jtei.framework
@@ -779,11 +779,11 @@
 										<String>${oxygenHome}/lib/xml-apis-ext.jar</String>
 										<String>${oxygenHome}/lib/log4j.jar</String>
 										<String>${oxygenHome}/lib/fop.jar</String>
-										<String>${oxygenHome}/lib/batik-all-1.7.jar</String>
-										<String>${oxygenHome}/lib/commons-logging-1.1.3.jar</String>
-										<String>${oxygenHome}/lib/xmlgraphics-commons-1.5.jar</String>
-										<String>${oxygenHome}/lib/commons-io-1.3.1.jar</String>
-										<String>${oxygenHome}/lib/avalon-framework-4.2.0.jar</String>
+										<String>${oxygenHome}/lib/batik-all-*.jar</String>
+										<String>${oxygenHome}/lib/commons-logging-*.jar</String>
+										<String>${oxygenHome}/lib/xmlgraphics-commons-*.jar</String>
+										<String>${oxygenHome}/lib/commons-io-*.jar</String>
+										<String>${oxygenHome}/lib/avalon-framework-*.jar</String>
 									</String-array>
 								</field>
 							</antScenario>


### PR DESCRIPTION
By replacing exact version numbers with wildcards in the classpath for an ANT task invoking FOP, version dependency is alleviated for the FOP jars that are included in the Oxygen release.