### PR TITLE
Removed text-align center from tables

### DIFF
--- a/oxygen-tei/frameworks/tei/xml/tei/css/tei.css
+++ b/oxygen-tei/frameworks/tei/xml/tei/css/tei.css
@@ -839,7 +839,6 @@ stage {
   font-style: italic;
 }
 table {
-  text-align: center;
   display: table;
   margin: 1em
 }


### PR DESCRIPTION
Removed text-align center from tables, publishing to HTML and PDF does not seem to center align cell contents so neither should the visual editor (IMHO)