### PR TITLE
add template and script for creating updateSite.oxygen

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ It is organized as follows:
 
 # If you just want to update your oXygen XML Editor framework for TEI
 If all you want to do is update your oXygen XML Editor framework for TEI to the latest release then
-the suggestions at http://blogs.it.ox.ac.uk/jamesc/2014/04/02/auto-update-your-tei-framework-in-oxygen/ 
+the (now out of date) suggestions at https://faqingperplxd.wordpress.com/2014/04/02/auto-update-your-tei-framework-in-oxygen/ 
 with some differences because of the changes in oXygen versions since then.  If you really wanted to get the 
 development version and have that auto-update you could point to the oxygen-tei-stable or oxygen-tei-bleeding 
 jobs on http://jenkins.tei-c.org e.g. http://jenkins.tei-c.org/job/oxygen-tei-stable/lastSuccessfulBuild/artifact/oxygen-tei/updateSite.oxygen but be warned that here be dragons.

--- a/oxygen-tei/updateSite.oxygen.templ
+++ b/oxygen-tei/updateSite.oxygen.templ
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xt:extensions xmlns:xt="http://www.oxygenxml.com/ns/extension"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.oxygenxml.com/ns/extension http://www.oxygenxml.com/ns/extension/extensions.xsd">
+    <xt:extension id="tei">
+        <xt:location href="https://jenkins.tei-c.org/job/oxygen-tei-stable/lastSuccessfulBuild/artifact/oxygen-tei/oxygen-tei-3.5.0-7.47.0.zip"/>
+        <xt:version>3.5.1</xt:version>
+        <xt:oxy_version>15.2+</xt:oxy_version>
+        <xt:type>framework</xt:type>
+        <xt:author>TEI Technical Council</xt:author>
+        <xt:name>TEI P5</xt:name>
+        
+        <xt:license>
+            
+            
+These material is dual-licensed:
+
+1. Distributed under a Creative Commons Attribution 3.0
+Unported License http://creativecommons.org/licenses/by/3.0/ 
+
+2. http://www.opensource.org/licenses/BSD-2-Clause
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+* Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+This software is provided by the copyright holders and contributors
+"as is" and any express or implied warranties, including, but not
+limited to, the implied warranties of merchantability and fitness for
+a particular purpose are disclaimed. In no event shall the copyright
+holder or contributors be liable for any direct, indirect, incidental,
+special, exemplary, or consequential damages (including, but not
+limited to, procurement of substitute goods or services; loss of use,
+data, or profits; or business interruption) however caused and on any
+theory of liability, whether in contract, strict liability, or tort
+(including negligence or otherwise) arising in any way out of the use
+of this software, even if advised of the possibility of such damage.
+            
+            
+        </xt:license>
+        
+        <xt:description>TEI
+            schemas and stylesheets. To avoid conflict with builtin framework, please ensure that
+            you have gone to Preferences->Document Type Association in
+            oXygen and deactivated all the TEI frameworks
+            that have "External" in the storage columns.</xt:description>
+    </xt:extension>
+</xt:extensions>

--- a/oxygen-tei/updateSite.oxygenFromGithubReleases.xsl
+++ b/oxygen-tei/updateSite.oxygenFromGithubReleases.xsl
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:xt="http://www.oxygenxml.com/ns/extension"
+    xmlns:xd="http://www.oxygenxml.com/ns/doc/xsl"
+    xmlns:map="http://www.w3.org/2005/xpath-functions/map"
+    xmlns:array="http://www.w3.org/2005/xpath-functions/array"
+    exclude-result-prefixes="xs"
+    version="3.0">
+    
+    <xd:doc scope="stylesheet">
+        <xd:desc>
+            <xd:p><xd:b>Created on:</xd:b> April 9, 2019</xd:p>
+            <xd:p><xd:b>Author:</xd:b> Peter Stadler</xd:p>
+            <xd:p>This stylesheet processes an updateSite.oxygen file
+                and uses the first xt:extension element as template,
+                It checks the GitHub API for all releases of the 
+                oxygen-tei plugin and creates xt:extension elements 
+                for every release by processing the above template.
+            </xd:p>
+        </xd:desc>
+    </xd:doc>
+    
+    <xsl:param name="releases.endpoint" 
+        select="'https://api.github.com/repos/TEIC/oxygen-tei/releases'" 
+        as="xs:string"/>
+    
+    <xsl:variable name="github.releases" 
+        select="json-doc($releases.endpoint)" 
+        as="array(*)"/>
+    <xsl:variable name="extension.template" 
+        select=".//xt:extension[1]" 
+        as="element(xt:extension)?"/>
+    
+    <xsl:template match="/">
+        <xsl:apply-templates/>
+    </xsl:template>
+    
+    <xsl:template match="xt:extensions">
+        <xsl:copy>
+            <xsl:apply-templates select="@*"/>
+            <!-- iterate over releases array from GitHub API -->
+            <xsl:for-each select="$github.releases?*">
+                <!-- … and process our $extension.template for each array member -->
+                <xsl:apply-templates select="$extension.template">
+                    <!-- … with the tunneled JSON object (= a release) -->
+                    <xsl:with-param name="model" select="." tunnel="yes"/>
+                </xsl:apply-templates>
+            </xsl:for-each>
+        </xsl:copy>
+    </xsl:template>
+    
+    <xsl:template match="xt:version">
+        <xsl:param name="model" tunnel="yes"/>
+        <xsl:copy>
+            <!-- strip off the leading 'v' from the version number (e.g. 'v8.0.0') -->
+            <xsl:value-of select="substring($model?tag_name, 2)"/>
+        </xsl:copy>
+    </xsl:template>
+    
+    <xsl:template match="xt:location">
+        <xsl:param name="model" tunnel="yes"/>
+        <xsl:copy>
+            <xsl:attribute name="href">
+                <xsl:value-of select="$model?assets?*?browser_download_url"/>
+            </xsl:attribute>
+        </xsl:copy>
+    </xsl:template>
+    
+    <xsl:template match="node() | @*">
+        <xsl:copy>
+            <xsl:apply-templates select="node() | @*"/>
+        </xsl:copy>
+    </xsl:template>
+    
+</xsl:stylesheet>


### PR DESCRIPTION
from GitHub releases. For every release one xt:extension entry will be created.

I'm unsure about both the current directory structure of the repo and whether to replace the current mechanism of creating the updateSite.oxygen entirely with this approach. Feedback and updates to the PR welcome!