### PR TITLE
fixed jeuclid classpath for PDF transformations in older versions of …

### DIFF
--- a/oxygen-tei/frameworks/tei/teip5jtei.framework
+++ b/oxygen-tei/frameworks/tei/teip5jtei.framework
@@ -808,7 +808,7 @@
 			                                                    <String>${oxygenHome}/lib/xmlgraphics-commons-1.5.jar</String>
 			                                                    <String>${oxygenHome}/lib/commons-io-1.3.1.jar</String>
 			                                                    <String>${oxygenHome}/lib/avalon-framework-4.2.0.jar</String>
-			                                                    <String>${oxygenHome}/lib/oxygen-patched-jeuclid-core.jar</String>
+			                                                    <String>${oxygenHome}/lib/jeuclid-core.jar</String>
 			                                                    <!-- wildcards for future compatibility (supported from Oxygen-18.0) -->
 			                                                    <!-- this way, the framework will find relevant jars if FOP is updated -->
 			                                                    <String>${oxygenHome}/lib/*batik*.jar</String>


### PR DESCRIPTION
…Oxygen:

  -older Oxygen: include ${oxygenHome}/lib/jeuclid-core.jar
  -from Oxygen-21: include ${oxygenHome}/lib/oxygen-patched-*.jar