### PR TITLE
Use wildcards for log4j in classpaths

### DIFF
--- a/oxygen-tei/frameworks/tei/teip5.framework
+++ b/oxygen-tei/frameworks/tei/teip5.framework
@@ -3268,7 +3268,7 @@ ancestor-or-self::node()[self::*:row | self::*:list][1][self::*:row]</String>
 										<String>${oxygenHome}/lib/*saxon*9*.jar</String>
 										<String>${oxygenHome}/lib/saxon*6*.jar</String>
 										<String>${oxygenHome}/lib/xml-apis-ext.jar</String>
-										<String>${oxygenHome}/lib/log4j.jar</String>
+										<String>${oxygenHome}/lib/*log4j*.jar</String>
 										<String>${oxygenHome}/lib/oxygen-basic-utilities.jar</String>
 									</String-array>
 								</field>
@@ -3500,7 +3500,7 @@ ancestor-or-self::node()[self::*:row | self::*:list][1][self::*:row]</String>
 										<String>${oxygenHome}/lib/*saxon*9*.jar</String>
 										<String>${oxygenHome}/lib/saxon*6*.jar</String>
 										<String>${oxygenHome}/lib/xml-apis-ext.jar</String>
-										<String>${oxygenHome}/lib/log4j.jar</String>
+										<String>${oxygenHome}/lib/*log4j*.jar</String>
 										<String>${oxygenHome}/lib/oxygen-basic-utilities.jar</String>
 									</String-array>
 								</field>
@@ -3732,7 +3732,7 @@ ancestor-or-self::node()[self::*:row | self::*:list][1][self::*:row]</String>
 										<String>${oxygenHome}/lib/*saxon*9*.jar</String>
 										<String>${oxygenHome}/lib/saxon*6*.jar</String>
 										<String>${oxygenHome}/lib/xml-apis-ext.jar</String>
-										<String>${oxygenHome}/lib/log4j.jar</String>
+										<String>${oxygenHome}/lib/*log4j*.jar</String>
 										<String>${oxygenHome}/lib/oxygen-basic-utilities.jar</String>
 									</String-array>
 								</field>

--- a/oxygen-tei/frameworks/tei/teip5jtei.framework
+++ b/oxygen-tei/frameworks/tei/teip5jtei.framework
@@ -564,7 +564,7 @@
 										<String>${oxygenHome}/lib/saxon9ee.jar</String>
 										<String>${oxygenHome}/lib/saxon.jar</String>
 										<String>${oxygenHome}/lib/xml-apis-ext.jar</String>
-										<String>${oxygenHome}/lib/log4j.jar</String>
+										<String>${oxygenHome}/lib/*log4j*.jar</String>
 										<String>${oxygenHome}/lib/fop.jar</String>
 									  <String>${framework(TEI P5)}/xml/tei/jtei_aux/trans/</String>
 									  <!-- explicit filenames for backward compatibility (down to Oxygen-16.0) -->
@@ -799,7 +799,7 @@
 			                                                    <String>${oxygenHome}/lib/resolver.jar</String>
 			                                                    <String>${oxygenHome}/lib/xercesImpl.jar</String>
 			                                                    <String>${oxygenHome}/lib/saxon9ee.jar</String>
-			                                                    <String>${oxygenHome}/lib/log4j.jar</String>
+			                                                    <String>${oxygenHome}/lib/*log4j*.jar</String>
 			                                                    <String>${oxygenHome}/lib/fop.jar</String>
 			                                                    <String>${pdu}/oxygen_aux_files/ant/</String>
 			                                                    <!-- explicit filenames for backward compatibility (down to Oxygen-16.0) -->

--- a/oxygen-tei/frameworks/tei/teip5odd.framework
+++ b/oxygen-tei/frameworks/tei/teip5odd.framework
@@ -3029,7 +3029,7 @@
 		    <String>${oxygenHome}/lib/*saxon*9*.jar</String>
 		    <String>${oxygenHome}/lib/saxon.jar</String>
 		    <String>${oxygenHome}/lib/xml-apis-ext.jar</String>
-		    <String>${oxygenHome}/lib/log4j.jar</String>
+		    <String>${oxygenHome}/lib/*log4j*.jar</String>
 		  	<String>${oxygenHome}/lib/oxygen-basic-utilities.jar</String>
 		  </String-array>
 		</field>
@@ -3301,7 +3301,7 @@
 		    <String>${oxygenHome}/lib/*saxon*9*.jar</String>
 		    <String>${oxygenHome}/lib/saxon.jar</String>
 		    <String>${oxygenHome}/lib/xml-apis-ext.jar</String>
-		    <String>${oxygenHome}/lib/log4j.jar</String>
+		    <String>${oxygenHome}/lib/*log4j*.jar</String>
 		  	<String>${oxygenHome}/lib/oxygen-basic-utilities.jar</String>
 		  </String-array>
 		</field>
@@ -3573,7 +3573,7 @@
 		    <String>${oxygenHome}/lib/*saxon*9*.jar</String>
 		    <String>${oxygenHome}/lib/saxon.jar</String>
 		    <String>${oxygenHome}/lib/xml-apis-ext.jar</String>
-		    <String>${oxygenHome}/lib/log4j.jar</String>
+		    <String>${oxygenHome}/lib/*log4j*.jar</String>
 		  	<String>${oxygenHome}/lib/oxygen-basic-utilities.jar</String>
 		  </String-array>
 		</field>
@@ -3825,7 +3825,7 @@
 		    <String>${oxygenHome}/lib/*saxon*9*.jar</String>
 		    <String>${oxygenHome}/lib/saxon.jar</String>
 		    <String>${oxygenHome}/lib/xml-apis-ext.jar</String>
-		    <String>${oxygenHome}/lib/log4j.jar</String>
+		    <String>${oxygenHome}/lib/*log4j*.jar</String>
 		  	<String>${oxygenHome}/lib/oxygen-basic-utilities.jar</String>
 		  </String-array>
 		</field>
@@ -4077,7 +4077,7 @@
 		    <String>${oxygenHome}/lib/*saxon*9*.jar</String>
 		    <String>${oxygenHome}/lib/saxon.jar</String>
 		    <String>${oxygenHome}/lib/xml-apis-ext.jar</String>
-		    <String>${oxygenHome}/lib/log4j.jar</String>
+		    <String>${oxygenHome}/lib/*log4j*.jar</String>
 		  	<String>${oxygenHome}/lib/oxygen-basic-utilities.jar</String>
 		  </String-array>
 		</field>
@@ -4329,7 +4329,7 @@
 		    <String>${oxygenHome}/lib/*saxon*9*.jar</String>
 		    <String>${oxygenHome}/lib/saxon.jar</String>
 		    <String>${oxygenHome}/lib/xml-apis-ext.jar</String>
-		    <String>${oxygenHome}/lib/log4j.jar</String>
+		    <String>${oxygenHome}/lib/*log4j*.jar</String>
 		    <String>${oxygenHome}/lib/*trang*.jar</String>
 		  	<String>${oxygenHome}/lib/oxygen-basic-utilities.jar</String>
 		  </String-array>
@@ -4582,7 +4582,7 @@
 		    <String>${oxygenHome}/lib/*saxon*9*.jar</String>
 		    <String>${oxygenHome}/lib/saxon.jar</String>
 		    <String>${oxygenHome}/lib/xml-apis-ext.jar</String>
-		    <String>${oxygenHome}/lib/log4j.jar</String>
+		    <String>${oxygenHome}/lib/*log4j*.jar</String>
 		    <String>${oxygenHome}/lib/*trang*.jar</String>
 		  	<String>${oxygenHome}/lib/oxygen-basic-utilities.jar</String>
 		  </String-array>


### PR DESCRIPTION
Oxygen 22.1 will come a newer version of log4j so I updated the transformation scenario classpath to use wildcards so that they work with the new version as well as with older versions of Oxygen.