### PR TITLE
Update the configuration file for log4j 2.

### DIFF
--- a/oxygen-tei/frameworks/tei/teip5jtei.framework
+++ b/oxygen-tei/frameworks/tei/teip5jtei.framework
@@ -802,6 +802,7 @@
 			                                                    <String>${oxygenHome}/lib/*log4j*.jar</String>
 			                                                    <String>${oxygenHome}/lib/fop.jar</String>
 			                                                    <String>${pdu}/oxygen_aux_files/ant/</String>
+			                                                	<String>${framework(TEI P5)}/xml/tei/jtei_aux/trans/</String>
 			                                                    <!-- explicit filenames for backward compatibility (down to Oxygen-16.0) -->
 			                                                    <!-- (wildcards in these paths aren't supported before Oxygen-18.0) -->
 			                                                    <String>${oxygenHome}/lib/batik-all-1.7.jar</String>

--- a/oxygen-tei/frameworks/tei/xml/tei/jtei_aux/trans/log4j.properties
+++ b/oxygen-tei/frameworks/tei/xml/tei/jtei_aux/trans/log4j.properties
@@ -1,3 +1,4 @@
+## Log4j configuration file for Oxygen version 22 and older
 # ALL < DEBUG < INFO < WARN < ERROR < FATAL < OFF
 log4j.rootCategory=ERROR, R
 

--- a/oxygen-tei/frameworks/tei/xml/tei/jtei_aux/trans/log4j2.properties
+++ b/oxygen-tei/frameworks/tei/xml/tei/jtei_aux/trans/log4j2.properties
@@ -1,0 +1,12 @@
+### Log4j 2 configuration file for Oxygen version 22.1 and newer.
+name = PropertiesConfig
+status=error
+
+appender.R.type = Console
+appender.R.name = R
+appender.R.layout.type = PatternLayout
+appender.R.layout.pattern = %r %p [ %t ] %c - %m%n
+
+# ALL < DEBUG < INFO < WARN < ERROR < FATAL < OFF
+rootLogger.level = ERROR
+rootLogger.appenderRef.stdout.ref = R


### PR DESCRIPTION
Hi,
Starting to version 22.1, Oxygen uses version 2 of the Apache Log4j library. Log4j2 has a different configuration syntax and searches for a configuration file with the name "log4j2". I added this new configuration file.

Regards,
Cosmin Duna
Oxygen XML Editor 